### PR TITLE
Add a new signature (just pass in a string) and use can-define to set up List and Map if they’re not passed in

### DIFF
--- a/can-realtime-rest-model-test.js
+++ b/can-realtime-rest-model-test.js
@@ -134,3 +134,10 @@ QUnit.test("basics", function(assert){
     });
 
 });
+
+QUnit.test("string signature", function(assert) {
+    var connection = realtimeRestModel("/api/todos/{_id}");
+
+    assert.ok(new connection.Map() instanceof DefineMap, "Map defined");
+    assert.ok(new connection.List() instanceof DefineList, "List defined");
+});

--- a/can-realtime-rest-model.js
+++ b/can-realtime-rest-model.js
@@ -6,11 +6,24 @@ var constructorStore = require("can-connect/constructor/store/store");
 var dataCallbacks = require("can-connect/data/callbacks/callbacks");
 var dataParse = require("can-connect/data/parse/parse");
 var dataUrl = require("can-connect/data/url/url");
+var DefineList = require("can-define/list/list");
+var DefineMap = require("can-define/map/map");
 var realTime = require("can-connect/real-time/real-time");
 var callbacksOnce = require("can-connect/constructor/callbacks-once/callbacks-once");
 var namespace = require("can-namespace");
 
-function realtimeRestModel(options){
+function realtimeRestModel(optionsOrUrl) {
+
+	// If optionsOrUrl is a string, make options = {url: optionsOrUrl}
+	var options = (typeof optionsOrUrl === "string") ? {url: optionsOrUrl} : optionsOrUrl;
+
+	// If options.Map or .List aren’t provided, define them
+	if (typeof options.Map === "undefined") {
+		options.Map = DefineMap.extend({seal: false}, {});
+	}
+	if (typeof options.List === "undefined") {
+		options.List = options.Map.List || DefineList.extend({"#": options.Map});
+	}
 
 	var behaviors = [
 		constructor,

--- a/can-realtime-rest-model.md
+++ b/can-realtime-rest-model.md
@@ -1,6 +1,7 @@
 @module {function} can-realtime-rest-model
 @parent can-data-modeling
 @collection can-core
+@package ./package.json
 @outline 2
 
 @description Connect a type to a restful data source and automatically manage
@@ -97,6 +98,38 @@ Todo.getList().then(todos => {
 
 @return {connection} A connection that is the combination of the options and all the behaviors
 that `realtimeRestModel` adds.
+
+@signature `realtimeRestModel(url)`
+
+Create a connection with just a url. Use this if you do not need to pass in any other `options` to configure the connection.
+
+For example, the following creates a `Todo` type with the ability to connect to a restful service layer:
+
+```js
+import {todoFixture} from "//unpkg.com/can-demo-models@5";
+import {realtimeRestModel} from "can";
+
+// Creates a mock backend with 5 todos
+todoFixture(5);
+
+const Todo = realtimeRestModel("/api/todos/{id}").Map;
+
+// Prints out all todo names
+
+Todo.getList().then(todos => {
+    todos.forEach(todo => {
+        console.log(todo.name);
+    })
+})
+```
+  @codepen
+
+@param {String} url The [can-connect/data/url/url.url] used to create, retrieve, update and
+  delete data.
+
+@return {connection} A connection that is the combination of the options and all the behaviors
+that `realtimeRestModel` adds. The `connection` includes a `Map` property which is the type
+constructor function used to create instances of the raw record data retrieved from the server.
 
 
 @body

--- a/package.json
+++ b/package.json
@@ -42,15 +42,15 @@
     ]
   },
   "dependencies": {
-    "can-connect": "^3.0.0-pre.0",
+    "can-connect": "^3.0.0",
+    "can-define": "^2.2.0",
     "can-globals": "^1.0.1",
     "can-namespace": "^1.0.0",
     "can-query-logic": "<2.0.0",
     "can-reflect": "^1.15.2"
   },
   "devDependencies": {
-    "can-fixture": "^3.0.0-pre.3",
-    "can-define": "^2.2.0",
+    "can-fixture": "^3.0.0",
     "jshint": "^2.9.1",
     "steal": "^1.6.5",
     "steal-qunit": "^1.0.1",


### PR DESCRIPTION
This makes the following possible:

```js
const Todo = realtimeRestModel("/api/todos/{id}").Map;
```

- Pass in just a string to `realtimeRestModel()` to configure the connection
- If `Map` or `List` aren’t defined in the options, then `can-define` is used by default

Closes https://github.com/canjs/can-realtime-rest-model/issues/4

Here’s the new signature:
<img width="964" alt="screen shot 2019-02-22 at 9 43 35 am" src="https://user-images.githubusercontent.com/10070176/53260627-cfb87280-3686-11e9-8bff-b294113aff26.png">
