### PR TITLE
Replace can-define with can-observable-*

### DIFF
--- a/can-realtime-rest-model.js
+++ b/can-realtime-rest-model.js
@@ -6,23 +6,28 @@ var constructorStore = require("can-connect/constructor/store/store");
 var dataCallbacks = require("can-connect/data/callbacks/callbacks");
 var dataParse = require("can-connect/data/parse/parse");
 var dataUrl = require("can-connect/data/url/url");
-var DefineList = require("can-define/list/list");
-var DefineMap = require("can-define/map/map");
+var ObservableArray = require("can-observable-array");
+var ObservableObject = require("can-observable-object");
 var realTime = require("can-connect/real-time/real-time");
 var callbacksOnce = require("can-connect/constructor/callbacks-once/callbacks-once");
 var namespace = require("can-namespace");
+var type = require("can-type");
 
 function realtimeRestModel(optionsOrUrl) {
 
 	// If optionsOrUrl is a string, make options = {url: optionsOrUrl}
 	var options = (typeof optionsOrUrl === "string") ? {url: optionsOrUrl} : optionsOrUrl;
 
-	// If options.Map or .List aren’t provided, define them
-	if (typeof options.Map === "undefined") {
-		options.Map = DefineMap.extend({seal: false}, {});
+	// If options.ObjectType or .ArrayType aren’t provided, define them
+	if (typeof options.ObjectType === "undefined") {
+		options.ObjectType = class extends ObservableObject {};
 	}
-	if (typeof options.List === "undefined") {
-		options.List = options.Map.List || DefineList.extend({"#": options.Map});
+	if (typeof options.ArrayType === "undefined") {
+		options.ArrayType = class extends ObservableArray {
+			static get items() {
+				return type.convert(options.ObjectType);
+			}
+		};
 	}
 
 	var behaviors = [

--- a/can-realtime-rest-model.js
+++ b/can-realtime-rest-model.js
@@ -20,10 +20,10 @@ function realtimeRestModel(optionsOrUrl) {
 
 	// If options.ObjectType or .ArrayType aren’t provided, define them
 	if (typeof options.ObjectType === "undefined") {
-		options.ObjectType = class extends ObservableObject {};
+		options.ObjectType = class DefaultObjectType extends ObservableObject {};
 	}
 	if (typeof options.ArrayType === "undefined") {
-		options.ArrayType = class extends ObservableArray {
+		options.ArrayType = class DefaultArrayType extends ObservableArray {
 			static get items() {
 				return type.convert(options.ObjectType);
 			}

--- a/can-realtime-rest-model.md
+++ b/can-realtime-rest-model.md
@@ -314,7 +314,7 @@ Todo.connection = realtimeRestModel({
 
 class TodoDetails extends StacheElement {
     static view = `
-        Todo name is: {{this.todoPromise.value.name}}
+        Todo name is: {{ this.todoPromise.value.name }}
     `;
 
     static props = {

--- a/can-realtime-rest-model.md
+++ b/can-realtime-rest-model.md
@@ -235,13 +235,13 @@ Todo.connection = realtimeRestModel({
 class TodoList extends StacheElement {
     static view = `
       <ul>
-          {{# if(todosPromise.isResolved) }}
-              {{# for(todo of todosPromise.value) }}
+          {{# if(this.todosPromise.isResolved) }}
+              {{# for(todo of this.todosPromise.value) }}
                   <li>
                       <label>{{todo.name}}</label>
                   </li>
               {{/ for }}
-          {{/ if}}
+          {{/ if }}
       </ul>
     `;
 
@@ -261,10 +261,10 @@ class TodoCreate extends StacheElement {
         <form on:submit="createTodo(scope.event)">
             <p>
                 <label>Name</label>
-                <input on:input:value:bind="todo.name" />
+                <input on:input:value:bind="this.todo.name" />
             </p>
-            <button disabled:from="todo.isSaving()">Create Todo</button>
-            {{# if(todo.isSaving()) }}Creating…{{/ if}}
+            <button disabled:from="this.todo.isSaving()">Create Todo</button>
+            {{# if(this.todo.isSaving()) }}Creating…{{/ if }}
         </form>
     `;
 
@@ -314,7 +314,7 @@ Todo.connection = realtimeRestModel({
 
 class TodoDetails extends StacheElement {
     static view = `
-        Todo Name is: {{todoPromise.value.name}}
+        Todo name is: {{this.todoPromise.value.name}}
     `;
 
     static props = {
@@ -332,7 +332,7 @@ customElements.define("todo-details", TodoDetails);
 
 class TodoEdit extends StacheElement {
     static view = `
-        Todo name is: <input value:bind="todoPromise.value.name"/>
+        Todo name is: <input value:bind="this.todoPromise.value.name"/>
     `;
 
     static props = {

--- a/can-realtime-rest-model.md
+++ b/can-realtime-rest-model.md
@@ -28,15 +28,15 @@ automatically. This is detailed in the [Purpose](#Purpose) section below.
 If your service layer matches what `realtimeRestModel` expects, configuring `realtimeRestModel` is very simple. For example, the following extends a `Todo` type with the ability to connect to a restful service layer:
 
 ```js
-import {Todo, todoFixture} from "//unpkg.com/can-demo-models@5";
-import {realtimeRestModel} from "can";
+import { Todo, todoFixture, TodoList } from "//unpkg.com/can-demo-models@6";
+import { realtimeRestModel } from "can";
 
 // Creates a mock backend with 5 todos
 todoFixture(5);
 
 Todo.connection = realtimeRestModel({
-    Map: Todo,
-    List: Todo.List,
+    ArrayType: TodoList,
+    ObjectType: Todo,
     url: "/api/todos/{id}"
 });
 
@@ -45,14 +45,14 @@ Todo.connection = realtimeRestModel({
 Todo.getList().then(todos => {
     todos.forEach(todo => {
         console.log(todo.name);
-    })
-})
+    });
+});
 ```
   @codepen
 
 @param {Object} options Configuration options supported by all the mixed-in behaviors:
 
-- [can-connect/can/map/map._Map] - The map type constructor function used to create
+- [can-connect/can/map/map._Map ObjectType] - The map type constructor function used to create
   instances of the raw record data retrieved from the server.
   The type will also be decorated
   with the following methods:
@@ -64,7 +64,7 @@ Todo.getList().then(todos => {
   - [can-connect/can/map/map.prototype.isDestroying]
   - [can-connect/can/map/map.prototype.isNew]
 
-- [can-connect/can/map/map._List] - The list type constructor function used to create
+- [can-connect/can/map/map._List ArrayType] - The list type constructor function used to create
   a list of instances of the raw record data retrieved from the server. <span style="display:none">_</span>
 - [can-connect/data/url/url.url] - Configure the URLs used to create, retrieve, update and
   delete data. It can be configured with a single url like:
@@ -84,7 +84,7 @@ Todo.getList().then(todos => {
     destroyData: "POST /api/todo/delete?id={id}"
   }
   ```
-- [can-connect/data/url/url.ajax] - Specify a method to use to make requests; [can-ajax] is used by default, but jQuery's `.ajax` method can be passed.
+- [can-connect/data/url/url.ajax] - Specify a method to use to make requests; [can-ajax] is used by default, but jQuery’s `.ajax` method can be passed.
 - [can-connect/data/parse/parse.parseInstanceProp] - Specify the property to find the data that represents an instance item.
 - [can-connect/data/parse/parse.parseInstanceData] - Returns the properties that should be used to
   [can-connect/constructor/constructor.hydrateInstance make an instance]
@@ -94,7 +94,7 @@ Todo.getList().then(todos => {
 - [can-connect/data/parse/parse.parseListProp] Specify the property to find the list data within a `getList` response.
 - [can-connect/data/parse/parse.parseListData] Return the correctly formatted data for a `getList` response.
 - [can-connect/base/base.queryLogic] - Specify the identity properties of the
-  type. This is built automatically from the `Map` if [can-define/map/map] is used.
+  type. This is built automatically from the `ObjectType` if [can-observable-object] is used.
 
 @return {connection} A connection that is the combination of the options and all the behaviors
 that `realtimeRestModel` adds.
@@ -106,21 +106,20 @@ Create a connection with just a url. Use this if you do not need to pass in any 
 For example, the following creates a `Todo` type with the ability to connect to a restful service layer:
 
 ```js
-import {todoFixture} from "//unpkg.com/can-demo-models@5";
+import {todoFixture} from "//unpkg.com/can-demo-models@6";
 import {realtimeRestModel} from "can";
 
 // Creates a mock backend with 5 todos
 todoFixture(5);
 
-const Todo = realtimeRestModel("/api/todos/{id}").Map;
+const Todo = realtimeRestModel("/api/todos/{id}").ObjectType;
 
 // Prints out all todo names
-
 Todo.getList().then(todos => {
     todos.forEach(todo => {
         console.log(todo.name);
-    })
-})
+    });
+});
 ```
   @codepen
 
@@ -128,7 +127,7 @@ Todo.getList().then(todos => {
   delete data.
 
 @return {connection} A connection that is the combination of the options and all the behaviors
-that `realtimeRestModel` adds. The `connection` includes a `Map` property which is the type
+that `realtimeRestModel` adds. The `connection` includes an `ObjectType` property which is the type
 constructor function used to create instances of the raw record data retrieved from the server.
 
 
@@ -153,26 +152,29 @@ displays only completed todos sorted by name like:
 <completed-todos />
 
 <script>
-import {Component} from "can";
-import {Todo} from "../models/todo";
+import { StacheElement } from "can";
+import { Todo } from "../models/todo";
 
-Component.extend({
-    tag: "completed-todos",
-    view: `
+class CompletedTodos extends StacheElement {
+    static view = `
         <h2>Completed Todos</h2>
         {{#each(todosPromise.value)}}
             <li>{{name}}</li>
         {{/each}}
-    `,
-    ViewModel: {
+    `;
+
+    static props = {
         todosPromise: {
-            default: () => Todo.getList({
-                filter: {complete: true},
-                sort: "name"
-            })
+            get default() {
+                return Todo.getList({
+                    filter: {complete: true},
+                    sort: "name"
+                });
+            }
         }
-    }
-})
+    };
+}
+customElements.define("completed-todos", CompletedTodos);
 </script>
 ```
 
@@ -180,26 +182,26 @@ If other components are creating, updating, or destroying todos, this component
 will update automatically. For example:
 
 - Creating a completed todo as follows will automatically insert the todo
-  in the `<completed-todos>` element's list sorted by its name:
+  in the `<completed-todos>` element’s list sorted by its name:
 
   ```js
   new Todo({name: "walk dog", complete: true}).save();
   ```
   This works because [can-query-logic] is able to know that the query
-  `{ filter: {complete: true}, sort: "name" }` doesn't contain data like
+  `{ filter: {complete: true}, sort: "name" }` doesn’t contain data like
   `{name: "walk dog", complete: true}`.
 
-- Creating a todo with `complete: false` will __not__ update the `<completed-todos>`'s list:
+- Creating a todo with `complete: false` will __not__ update the `<completed-todos>`’s ArrayType:
   ```js
   new Todo({name: "walk dog", complete: false}).save();
   ```
   This works because [can-query-logic] is able to know that the query
-  `{ filter: {complete: true}, sort: "name" }` doesn't contain data like
+  `{ filter: {complete: true}, sort: "name" }` doesn’t contain data like
   `{name: "walk dog", complete: false}`.
 
-- Updating a todo's `name` or `complete` value will move the todo
-  in or out of the `<completed-todos>`'s list and put it in the
-  right position.  For example, a todo that's not complete can be
+- Updating a todo’s `name` or `complete` value will move the todo
+  in or out of the `<completed-todos>`’s list and put it in the
+  right position.  For example, a todo that’s not complete can be
   moved into the list like:
 
   ```js
@@ -218,64 +220,70 @@ The following code example uses `realtimeRestModel` to create a list of todos th
 <todo-list></todo-list>
 
 <script type="module">
-import {realtimeRestModel, Component} from "can";
-import {Todo, todoFixture} from "//unpkg.com/can-demo-models@5";
+import { realtimeRestModel, StacheElement } from "can";
+import { Todo, todoFixture, TodoList } from "//unpkg.com/can-demo-models@6";
 
 // Creates a mock backend with 5 todos
 todoFixture(5);
 
 Todo.connection = realtimeRestModel({
-    Map: Todo,
-    List: Todo.List,
+    ArrayType: TodoList,
+    ObjectType: Todo,
     url: "/api/todos/{id}"
 });
 
-Component.extend({
-    tag: "todo-list",
-    view: `
-    <ul>
-        {{# if(todosPromise.isResolved) }}
-            {{# each(todosPromise.value) }}
-                <li>
-                    <label>{{name}}</label>
-                </li>
-            {{/ each }}
-        {{/ if}}
-    </ul>
-    `,
-    ViewModel: {
+class TodoList extends StacheElement {
+    static view = `
+      <ul>
+          {{# if(todosPromise.isResolved) }}
+              {{# for(todo of todosPromise.value) }}
+                  <li>
+                      <label>{{todo.name}}</label>
+                  </li>
+              {{/ for }}
+          {{/ if}}
+      </ul>
+    `;
+
+    static props = {
         todosPromise: {
-            get(){
+            get() {
                 return Todo.getList();
             }
         }
-    }
-});
+    };
+}
 
-Component.extend({
-    tag: "todo-create",
-    view: `
+customElements.define("todo-list", TodoList);
+
+class TodoCreate extends StacheElement {
+    static view = `
         <form on:submit="createTodo(scope.event)">
             <p>
                 <label>Name</label>
-                <input on:input:value:bind='todo.name'/>
+                <input on:input:value:bind="todo.name" />
             </p>
             <button disabled:from="todo.isSaving()">Create Todo</button>
-            {{# if(todo.isSaving()) }}Creating ....{{/ if}}
+            {{# if(todo.isSaving()) }}Creating…{{/ if}}
         </form>
-    `,
-    ViewModel: {
+    `;
+
+    static props = {
         todo: {
-            Default: Todo
-        },
-        createTodo(event) {
-            event.preventDefault();
-            this.todo.save().then((createdTodo) => {
-                this.todo = new Todo();
-            })
+            get default() {
+                return new Todo();
+            }
         }
+    };
+
+    createTodo(event) {
+        event.preventDefault();
+        this.todo.save().then((createdTodo) => {
+            this.todo = new Todo();
+        });
     }
-});
+}
+customElements.define("todo-create", TodoCreate);
 </script>
 ```
 @codepen
@@ -292,51 +300,59 @@ and shared. For example, if a `<todo-details>` widget loads the `id=5` todo, and
 <todo-details></todo-details>
 
 <script type="module">
-import {realtimeRestModel, Component} from "can";
-import {Todo, todoFixture} from "//unpkg.com/can-demo-models@5";
+import { realtimeRestModel, StacheElement } from "can";
+import { Todo, todoFixture, TodoList } from "//unpkg.com/can-demo-models@6";
 
 // Creates a mock backend with 6 todos
 todoFixture(6);
 
 Todo.connection = realtimeRestModel({
-    Map: Todo,
-    List: Todo.List,
+    ArrayType: TodoList,
+    ObjectType: Todo,
     url: "/api/todos/{id}"
 });
 
-Component.extend({
-    tag: "todo-details",
-    view: `
+class TodoDetails extends StacheElement {
+    static view = `
         Todo Name is: {{todoPromise.value.name}}
-    `,
-    ViewModel: {
-        todoPromise: {
-            default: () => Todo.get({
-                id: 5
-            })
-        }
-    }
-})
+    `;
 
-Component.extend({
-    tag: "todo-edit",
-    view: `
-        Todo name is: <input value:bind="todoPromise.value.name"/>
-    `,
-    ViewModel: {
+    static props = {
         todoPromise: {
-            default: () => Todo.get({
-                id: 5
-            })
+            get default() {
+                return Todo.get({
+                    id: 5
+                });
+            }
         }
-    }
-})
+    };
+}
+
+customElements.define("todo-details", TodoDetails);
+
+class TodoEdit extends StacheElement {
+    static view = `
+        Todo name is: <input value:bind="todoPromise.value.name"/>
+    `;
+
+    static props = {
+        todoPromise: {
+            get default() {
+                return Todo.get({
+                    id: 5
+                });
+            }
+        }
+    };
+}
+
+customElements.define("todo-edit", TodoEdit);
 
 </script>
 ```
 @codepen
 
-If the user changes the todo's name in the `<todo-edit>` widget, the` <todo-details>`
+If the user changes the todo’s name in the `<todo-edit>` widget, the` <todo-details>`
 widget will be automatically updated.
 
 Furthermore, if you wish to update the data in the page, you simply need to re-request the
@@ -344,10 +360,10 @@ data like:
 
 ```js
 // Updates the id=5 todo instance
-Todo.get({id: 5})
+Todo.get({ id: 5 });
 
 // Updates all incomplete todos
-Todo.getList({ filter: { complete: false } })
+Todo.getList({ filter: { complete: false } });
 ```
 
 
@@ -359,7 +375,7 @@ read the _"Use"_ section of [can-rest-model] before reading this _"Use"_ section
 This _"Use"_ section details knowledge needed in addition to  [can-rest-model]
 to use `realtimeRestModel`, such as:
 
-- Configuring queryLogic
+- Configuring [can-connect/base/base.queryLogic]
 - Updating the page from server-side events  
 - Simulating server-side events with [can-fixture]
 
@@ -367,7 +383,7 @@ to use `realtimeRestModel`, such as:
 
 `realtimeRestModel` requires a properly
 configured [can-connect/base/base.queryLogic]. If your server supports
-`getList` parameters that match [can-query-logic/query can-query-logic's default query structure], then no configuration
+`getList` parameters that match [can-query-logic/query can-query-logic’s default query structure], then no configuration
 is likely necessary. The default `query` structure looks like:
 
 ```js
@@ -385,7 +401,7 @@ Todo.getList({
 
 This structures follows the [Fetching Data JSONAPI specification](http://jsonapi.org/format/#fetching).
 
-There's a:
+There’s a:
 
 - [filter](http://jsonapi.org/format/#fetching-filtering) property for filtering records,
 - [sort](http://jsonapi.org/format/#fetching-sorting) property for specifying the order to sort records, and
@@ -404,30 +420,30 @@ to match your service layer, read
 
 ### Updating the page from server-side events  
 
-If your service layer can push events, you can call the connection's
+If your service layer can push events, you can call the connection’s
 [can-connect/real-time/real-time.createInstance],
 [can-connect/real-time/real-time.updateInstance], and [can-connect/real-time/real-time.destroyInstance]
 to update the lists and instances on the page.  For example, if you have a socket.io connection,
 you can listen to events and call these methods on the `connection` as follows:
 
 ```js
-import io from 'steal-socket.io';
+import io from "steal-socket.io";
 
 const todoConnection = realtimeRestModel({
-    Map: Todo,
-    List: TodoList,
+    ArrayType: TodoList,
+    ObjectType: Todo,
     url: "/api/todos/{id}"
 });
 
-socket.on('todo created', function(todo){
+socket.on("todo created", (todo) => {
   todoConnection.createInstance(todo);
 });
 
-socket.on('todo updated', function(todo){
+socket.on("todo updated", (todo) => {
   todoConnection.updateInstance(todo);
 });
 
-socket.on('todo removed', function(todo){
+socket.on("todo removed", (todo) => {
   todoConnection.destroyInstance(todo);
 });
 ```
@@ -440,35 +456,35 @@ can be done relatively easily by calling [can-connect/real-time/real-time.create
 on your connection directly as follows:
 
 ```js
-test("widget response to server-side events", function(assert){
-    let todoList = new TodoListComponent();
+test("widget response to server-side events", function(assert) {
+    const todoList = new TodoListComponent();
 
     todoConnection.createInstance({
         id: 5,
         name: "learn how to test",
         complete: false
-    }).then(function(){
+    }).then(function() {
         // check to see that the list has been updated
         assert.ok( /learn how to test/.test(todoList.element.innerHTML) );
     });
 });
 ```
 
-While this works, it doesn't make sure the record's data is in the fixture
+While this works, it doesn’t make sure the record’s data is in the fixture
 [can-fixture.store]. The fixture store also will add a unique `id`
 property. To make sure the record is in the store, use `store.createInstance` on the store and
 pass the result to `connection.createInstance` as follows:
 
 ```js
-test("widget response to server-side events", function(assert){
-    let todoList = new TodoListComponent();
+test("widget response to server-side events", function(assert) {
+    const todoList = new TodoListComponent();
 
     todoStore.createInstance({
         name: "learn how to test",
         complete: false
-    }).then(function(record){
-        return todoConnection.createInstance(record)
-    }).then(function(){
+    }).then(function(record) {
+        return todoConnection.createInstance(record);
+    }).then(function() {
         // check to see that the list has been updated
         assert.ok( /learn how to test/.test(todoList.element.innerHTML) );
     });

--- a/package.json
+++ b/package.json
@@ -44,12 +44,14 @@
     ]
   },
   "dependencies": {
-    "can-connect": "^3.0.0",
-    "can-define": "^2.2.0",
+    "can-connect": "^4.0.0-pre.1",
     "can-globals": "^1.0.1",
     "can-namespace": "^1.0.0",
-    "can-query-logic": "<2.0.0",
-    "can-reflect": "^1.15.2"
+    "can-observable-array": "^1.0.0-pre.7",
+    "can-observable-object": "^1.0.0-pre.3",
+    "can-query-logic": "^1.0.0",
+    "can-reflect": "^1.15.2",
+    "can-type": "^1.0.0-pre.5"
   },
   "devDependencies": {
     "can-fixture": "^3.0.0",

--- a/test-ie.html
+++ b/test-ie.html
@@ -1,4 +1,0 @@
-<!doctype html>
-<title>can-realtime-rest-model</title>
-<script src="node_modules/steal/steal-with-promises.js" main="can-realtime-rest-model/can-realtime-rest-model-test"></script>
-<div id="qunit-fixture"></div>

--- a/test-saucelabs.js
+++ b/test-saucelabs.js
@@ -2,10 +2,6 @@
 
 var SauceLabs = require("test-saucelabs");
 
-var maxDuration = 10800; // seconds, default 1800, max 10800
-var commandTimeout = 600; // seconds, default 300, max 600
-var idleTimeout = 1000; // seconds, default 90, max 1000
-
 // https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
 var platforms = [{
 	browserName: "safari",
@@ -31,17 +27,6 @@ var platforms = [{
 
 SauceLabs({
 	urls: [{
-		name: "can-realtime-rest-model",
-		url : 'http://localhost:3000/test-ie.html?hidepassed',
-		platforms: [{
-			browserName: 'internet explorer',
-			platform: 'Windows 10',
-			version: '11.0',
-			maxDuration: maxDuration,
-			commandTimeout: commandTimeout,
-			idleTimeout: idleTimeout
-		}]
-	}, {
 		name: "can-realtime-rest-model",
 		url: "http://localhost:3000/test.html?hidepassed",
 		platforms: platforms


### PR DESCRIPTION
This uses `can-observable-object` and `can-observable-array` as the defaults if no `ObjectType` or `ArrayType` are provided as `options`. The docs have also been updated to show the new packages.

Part of https://github.com/canjs/canjs/issues/5207

Closes https://github.com/canjs/can-realtime-rest-model/issues/13